### PR TITLE
feat: refactor UI components and script setup in App.vue

### DIFF
--- a/packages/renderer/src/App.vue
+++ b/packages/renderer/src/App.vue
@@ -1,43 +1,75 @@
 <template>
-  <v-responsive
-    class="border rounded"
-    height="100%"
-  >
-    <v-app :theme="theme">
-      <v-app-bar
-        height="50"
-        extension-height="64"
-      >
-        <v-app-bar-nav-icon></v-app-bar-nav-icon>
-        <v-app-bar-title>{{ titleHeader }}</v-app-bar-title>
-        <v-spacer></v-spacer>
+  <v-app :theme="theme">
+    <SideBar
+      :drawer="drawer"
+      :color="color[theme].container"
+    >
+      <template #drawerTrigger>
+        <v-app-bar-nav-icon @click="drawer = !drawer" />
+      </template>
+    </SideBar>
+    <HeadBar :color="color[theme].container">
+      <template #drawerTrigger>
+        <v-app-bar-nav-icon
+          v-show="!drawer"
+          @click="drawer = !drawer"
+        />
+      </template>
+      <template #themeTrigger>
         <v-btn
           :icon="theme === 'light' ? 'mdi-weather-sunny' : 'mdi-weather-night'"
           slim
           @click="onClick"
         />
-
-        <template #extension>
-          <WeekSwiper ref="weekSwiperRef" />
-        </template>
-      </v-app-bar>
-
-      <v-main>
+      </template>
+    </HeadBar>
+    <v-main
+      :class="clsx('bg-' + color[theme].container, 'overflow-auto  hide-scrollbar')"
+      :style="{height: `${mainHeight}px`}"
+    >
+      <v-container
+        :class="clsx('rounded-xl', 'bg-' + color[theme].main)"
+        fluid
+      >
         <Main />
-      </v-main>
-    </v-app>
-  </v-responsive>
+      </v-container>
+    </v-main>
+  </v-app>
 </template>
+
 <script setup>
 import {computed, ref} from 'vue';
 import Main from '/@/components/MainPage.vue';
-import WeekSwiper from '/@/components/WeekSwiper.vue';
+
+import clsx from 'clsx';
+import SideBar from '/@/layouts/SideBar.vue';
+import HeadBar from '/@/layouts/HeadBar.vue';
 
 const theme = ref('light');
-const weekSwiperRef = ref(null);
-const titleHeader = computed(() => weekSwiperRef.value?.headerTitle);
+const drawer = ref(true);
 
-function onClick() {
+const mainHeight = computed(() => window.innerHeight - 50 - 64);
+const color = ref({
+  light: {
+    main: 'grey-lighten-5',
+    container: 'grey-lighten-3',
+  },
+  dark: {
+    main: 'grey-darken-3',
+    container: 'grey-darken-4',
+  },
+});
+const onClick = () => {
   theme.value = theme.value === 'light' ? 'dark' : 'light';
-}
+};
 </script>
+<style scoped>
+.hide-scrollbar::-webkit-scrollbar {
+  display: none; /* hidden Chrome, Safari, and Opera scroller */
+}
+
+.hide-scrollbar {
+  -ms-overflow-style: none; /* IE and Edge */
+  scrollbar-width: none; /* Firefox */
+}
+</style>

--- a/packages/renderer/src/components/MainPage.vue
+++ b/packages/renderer/src/components/MainPage.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="d-flex flex-column align-center">
+  <div class="d-flex flex-column align-center rounded-xl">
     <h2>Main component</h2>
     <CreateTaskForm @task-added="handleTaskAdded" />
     <ShowAllTasks ref="showAllTasksComponent" />

--- a/packages/renderer/src/layouts/HeadBar.vue
+++ b/packages/renderer/src/layouts/HeadBar.vue
@@ -1,0 +1,29 @@
+<template>
+  <v-app-bar
+    height="75"
+    extension-height="64"
+    :color="color"
+    :elevation="0"
+  >
+    <slot name="drawerTrigger" />
+    <v-app-bar-title>{{ titleHeader }}</v-app-bar-title>
+    <v-spacer />
+    <slot name="themeTrigger" />
+    <template #extension>
+      <WeekSwiper ref="weekSwiperRef" />
+    </template>
+  </v-app-bar>
+</template>
+<script setup lang="ts">
+import WeekSwiper from '/@/components/WeekSwiper.vue';
+import {computed, ref} from 'vue';
+
+defineProps({
+  drawer: Boolean,
+  color: String,
+});
+
+const weekSwiperRef = ref<InstanceType<typeof WeekSwiper> | null>(null);
+const titleHeader = computed(() => weekSwiperRef.value?.headerTitle);
+</script>
+<style scoped></style>

--- a/packages/renderer/src/layouts/SideBar.vue
+++ b/packages/renderer/src/layouts/SideBar.vue
@@ -1,0 +1,46 @@
+<template>
+  <v-navigation-drawer
+    v-model="drawer"
+    app
+    permanent
+    floating
+    :color="color"
+  >
+    <v-list>
+      <v-list-item nav>
+        <slot name="drawerTrigger" />
+        <template #append>
+          <v-col cols="auto">
+            <v-btn
+              density="compact"
+              icon="mdi-plus"
+            ></v-btn>
+          </v-col>
+        </template>
+      </v-list-item>
+      <v-list-item>
+        <v-list-item-title class="title">Sidebar</v-list-item-title>
+      </v-list-item>
+      <v-list-item link>
+        <v-list-item-title>Link 1</v-list-item-title>
+      </v-list-item>
+      <v-list-item link>
+        <v-list-item-title>Link 2</v-list-item-title>
+      </v-list-item>
+      <v-list-item link>
+        <v-list-item-title>Link 3</v-list-item-title>
+      </v-list-item>
+    </v-list>
+  </v-navigation-drawer>
+</template>
+
+<script lang="ts" setup>
+import {toRefs} from 'vue';
+
+const props = defineProps({
+  drawer: Boolean,
+  color: String,
+});
+
+const {drawer} = toRefs(props);
+</script>


### PR DESCRIPTION
- Add a `SideBar` component with a `drawer` prop and `color` slot
- Add a `HeadBar` component with `color` prop and slots for `drawerTrigger` and `themeTrigger`
- Add `color` and `drawer` refs in the script setup of `App.vue`
- Remove a template slot for `extension` in `App.vue`
- Change the class of the `MainPage.vue` template to include `rounded-xl`