### PR TITLE
:recycle: Refactor task API integration across components

### DIFF
--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -4,6 +4,6 @@
 
 import {sha256sum} from './nodeCrypto';
 import {versions} from './versions';
-import './tasks';
+import {getAllTasksReq, getAllTaskTitlesReq, createTaskReq} from './tasks';
 
-export {sha256sum, versions};
+export {sha256sum, versions, getAllTasksReq, getAllTaskTitlesReq, createTaskReq};

--- a/packages/preload/src/tasks.ts
+++ b/packages/preload/src/tasks.ts
@@ -1,15 +1,11 @@
-import {contextBridge, ipcRenderer} from 'electron';
+import {ipcRenderer} from 'electron';
 import type {CreateTask, GetAllTasks, GetAllTaskTitles} from '/@/types/task';
 
-try {
-  contextBridge.exposeInMainWorld('tasksApi', {
-    getAllTasksReq: (...args: Parameters<GetAllTasks>) =>
-      ipcRenderer.invoke('getAllTasksReq', ...args),
-    getAllTaskTitlesReq: (...args: Parameters<GetAllTaskTitles>) =>
-      ipcRenderer.invoke('getAllTaskTitlesReq', ...args),
-    createTaskReq: (...args: Parameters<CreateTask>) =>
-      ipcRenderer.invoke('createTaskReq', ...args),
-  });
-} catch (error) {
-  console.error(error);
-}
+export const getAllTasksReq = async (...args: Parameters<GetAllTasks>) =>
+  ipcRenderer.invoke('getAllTasksReq', ...args);
+
+export const getAllTaskTitlesReq = async (...args: Parameters<GetAllTaskTitles>) =>
+  ipcRenderer.invoke('getAllTaskTitlesReq', ...args);
+
+export const createTaskReq = async (...args: Parameters<CreateTask>) =>
+  ipcRenderer.invoke('createTaskReq', ...args);

--- a/packages/renderer/src/components/CreateTaskForm.vue
+++ b/packages/renderer/src/components/CreateTaskForm.vue
@@ -24,6 +24,7 @@
 
 <script setup lang="ts">
 import {ref} from 'vue';
+import {createTaskReq} from '#preload';
 
 const taskTitle = ref('');
 const taskTitleRules = ref([(v: string) => !!v || 'Task title is required']);
@@ -32,7 +33,7 @@ const emit = defineEmits(['task-added']);
 
 const handleSubmit = async () => {
   try {
-    await window.tasksApi.createTaskReq({title: taskTitle.value});
+    await createTaskReq({title: taskTitle.value});
     taskTitle.value = '';
     emit('task-added');
   } catch (error) {

--- a/packages/renderer/src/components/ShowAllTasks.vue
+++ b/packages/renderer/src/components/ShowAllTasks.vue
@@ -24,12 +24,13 @@
 <script setup lang="ts">
 import {onBeforeMount, ref} from 'vue';
 import type {Task} from '/@/types/task';
+import {getAllTasksReq} from '#preload';
 
 const todoList = ref<Task[]>([]);
 
 const fetchTaskTitles = async () => {
   try {
-    const tasksArr = await window.tasksApi.getAllTasksReq();
+    const tasksArr = await getAllTasksReq();
     console.log('tasksArr', tasksArr);
     todoList.value = tasksArr;
   } catch (error) {


### PR DESCRIPTION
- Add `getAllTasksReq`, `getAllTaskTitlesReq`, and `createTaskReq` to `index.ts`
- Remove `contextBridge` and `try-catch` block from `tasks.ts`
- Change references from `window.tasksApi` to direct function calls in `CreateTaskForm.vue` and `ShowAllTasks.vue`